### PR TITLE
[BugFix] NBT가 있는 플레이어 머리 우클릭시 작동 안되는 오류 수정

### DIFF
--- a/src/main/kotlin/com/github/w0819/event/Event.kt
+++ b/src/main/kotlin/com/github/w0819/event/Event.kt
@@ -16,7 +16,6 @@ import org.bukkit.event.entity.EntityDeathEvent
 import org.bukkit.event.entity.EntityInteractEvent
 import org.bukkit.event.entity.PlayerDeathEvent
 import org.bukkit.event.inventory.CraftItemEvent
-import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.player.*
 import org.bukkit.inventory.Inventory
 import org.bukkit.inventory.ItemStack
@@ -24,7 +23,6 @@ import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.potion.PotionEffect
 import org.bukkit.potion.PotionEffectType
 import kotlin.random.Random
-
 
 class Event(private val plugin: JavaPlugin) : Listener {
 

--- a/src/main/kotlin/com/github/w0819/event/Event.kt
+++ b/src/main/kotlin/com/github/w0819/event/Event.kt
@@ -58,11 +58,12 @@ class Event(private val plugin: JavaPlugin) : Listener {
         var lowestDistanceSoFar = Double.MAX_VALUE
 
             if (event.action == Action.RIGHT_CLICK_AIR || event.action == Action.RIGHT_CLICK_BLOCK) {
+                if (event.item?.type == Material.PLAYER_HEAD) {
+                    player.inventory.removeItem(item)
+                    player.addPotionEffect(PotionEffect(PotionEffectType.REGENERATION,100,1,true,true))
+                    event.isCancelled = true
+                }
                 when(event.item) {
-                    item -> {
-                        player.inventory.removeItem(item)
-                        player.addPotionEffect(PotionEffect(PotionEffectType.REGENERATION,100,1,true,true))
-                    }
                     Item.Master_Compass -> {
                         player.inventory.removeItem(Item.Master_Compass)
                         for (entity in entities) { // This loops through all the entities, setting the variable "entity" to each element.


### PR DESCRIPTION
플레이어를 죽일 때 나오는 머리는 죽은 플레이어 마다 다른 NBT 태그와 나오기 때문에 수정하였습니다