### PR TITLE
버그 패치, 기능 추가 및 README 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,18 @@
 ## Hypixel의 UHC 시스템의 구현
 
 ### 공지
-이 프로젝트는 아직 완성되지 않았습니다. PullRequest 및 Issue로 아이디어 제공 및 구현을 
+이 프로젝트는 아직 완성되지 않았습니다. PR 및 Issue로 아이디어 제공 및 구현을 
 통해 완성을 도와주세요.
 
 ### 구현 완료
-
-- Hypixel UHC의 대부분의 레시피 추가
-- Hypixel UHC의 레시피북 추가
-- Hypixel UHC의 단계 추가
-- Hypixel UHC의 레시피 및 코인 시스템 추가
-- Hypixel UHC의 팀 시스템 추가
-- Hypixel UHC의 월드 생성
+- 레시피북
+- 게임 진행 단계
+- 코인
+- 팀
+- 월드 생성
 
 ### 구현 할 것
 
-- Hypixel UHC의 레시피 추가 완료
-- Hypixel UHC의 Game Modifier
-- Hypixel UHC의 키트들 추가
+- 추가 레시피
+- Game Modifier
+- 키트

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile;
 
 plugins {
-    kotlin("jvm") version "1.6.0"
+    kotlin("jvm") version "1.6.10"
 }
 
 val archiveName = rootProject.name
@@ -10,6 +10,11 @@ repositories {
     mavenCentral()
     maven("https://papermc.io/repo/repository/maven-public/")
 }
+
+configurations {
+    create("shade")
+}
+
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
@@ -17,20 +22,28 @@ java {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.10")
     implementation("io.papermc.paper:paper-api:1.18-R0.1-SNAPSHOT")
-    implementation("io.github.monun:tap-api:4.3.0")
+    implementation("io.github.monun:tap-api:4.3.1")
     implementation("io.github.monun:kommand-api:2.8.0")
-    implementation("net.projecttl:InventoryGUI-api:4.3.0")
+    configurations["shade"]("net.projecttl:InventoryGUI-api:4.3.0") {
+        exclude("org.jetbrains.kotlin")
+    }
     implementation("io.github.monun:heartbeat-coroutines:0.0.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2-native-mt")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
     implementation("io.github.dolphin2410:worldgen:0.0.2")
+}
+
+dependencies {
+    configurations["shade"].forEach {
+        implementation(files(it))
+    }
 }
 
 tasks {
 
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "16"
+        kotlinOptions.jvmTarget = "17"
     }
 
     processResources {
@@ -48,10 +61,14 @@ tasks {
 
         from(sourceSets["main"].output)
 
+        configurations["shade"].forEach {
+            from(if (it.isDirectory) it else zipTree(it))
+        }
+
         doLast {
             copy {
                 from(archiveFile)
-                val plugins = File(rootDir, ".server/plugins/")
+                val plugins = File(rootDir, ".1.18server/plugins/")
                 into(if (File(plugins, archiveFileName.get()).exists()) File(plugins, "update") else plugins)
             }
         }

--- a/src/main/kotlin/com/github/w0819/event/SystemEvent.kt
+++ b/src/main/kotlin/com/github/w0819/event/SystemEvent.kt
@@ -126,6 +126,7 @@ class SystemEvent(private val plugin: JavaPlugin) : Listener {
                 if (event.item?.type == Material.PLAYER_HEAD) {
                     player.inventory.removeItem(item)
                     player.addPotionEffect(PotionEffect(PotionEffectType.REGENERATION,100,1,true,true))
+                    player.addPotionEffect(PotionEffect(PotionEffectType.SPEED,100,1,true,true))
                     event.isCancelled = true
                 }
                 when(event.item) {

--- a/src/main/kotlin/com/github/w0819/game/util/Item.kt
+++ b/src/main/kotlin/com/github/w0819/game/util/Item.kt
@@ -18,6 +18,8 @@ object Item {
     var notch_apple = ItemStack(Material.ENCHANTED_GOLDEN_APPLE).apply {
     }
 
+    var Forge = ItemStack(Material.ANVIL)
+
     var HolyWater = ItemStack(Material.POTION).apply {
         itemMeta = itemMeta.apply {
             displayName(text("Holy Water").decorate(TextDecoration.ITALIC))

--- a/src/main/kotlin/com/github/w0819/game/util/UHCKits.kt
+++ b/src/main/kotlin/com/github/w0819/game/util/UHCKits.kt
@@ -9,17 +9,17 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 
 val choiceKit = NamespacedKey.minecraft("choice")
-private val empty = NamespacedKey.minecraft("emptyLevel")
-private val LeatherArmor = NamespacedKey.minecraft("LeatherArmorLevel")
-private val EnchantingSet = NamespacedKey.minecraft("EnchantingSetLevel")
-private val ArcherySet = NamespacedKey.minecraft("ArcherySetLevel")
-private val StoneGear = NamespacedKey.minecraft("StoneGearLevel")
-private val LunchBox = NamespacedKey.minecraft("LunchBoxLevel")
-private val Looter = NamespacedKey.minecraft("LooterLevel")
-private val Ecologist = NamespacedKey.minecraft("EcologistLevel")
-private val Farmer = NamespacedKey.minecraft("EcologistLevel")
-private val Horseman = NamespacedKey.minecraft("HorsemanLevel")
-private val Trapper = NamespacedKey.minecraft("TrapperLevel")
+private val empty = NamespacedKey.minecraft("empty_level")
+private val LeatherArmor = NamespacedKey.minecraft("leather_armor_level")
+private val EnchantingSet = NamespacedKey.minecraft("enchanting_set_level")
+private val ArcherySet = NamespacedKey.minecraft("archery_set_level")
+private val StoneGear = NamespacedKey.minecraft("stone_gear_level")
+private val LunchBox = NamespacedKey.minecraft("lunch_box_level")
+private val Looter = NamespacedKey.minecraft("looter_level")
+private val Ecologist = NamespacedKey.minecraft("ecologist_level")
+private val Farmer = NamespacedKey.minecraft("ecologist_level")
+private val Horseman = NamespacedKey.minecraft("horseman_level")
+private val Trapper = NamespacedKey.minecraft("trapper_level")
 
 enum class KitList {
     Empty,

--- a/src/main/kotlin/com/github/w0819/game/util/UHCRecipe.kt
+++ b/src/main/kotlin/com/github/w0819/game/util/UHCRecipe.kt
@@ -19,7 +19,9 @@ open class UHCRecipe(key: NamespacedKey, result: ItemStack): ShapedRecipe(key, r
                     recipes.add(Class.forName(fileName.replace("/", ".").removeSuffix(".class")).getDeclaredConstructor().newInstance() as UHCRecipe)
                 }
             }
-            return recipes.toTypedArray()
+            return recipes.toTypedArray().onEach {
+                it.register()
+            }
         }
     }
     fun register(): UHCRecipe {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ authors: [w0819, dolphin2410]
 libraries:
   - io.github.monun:tap:4.3.0
   - io.github.monun:kommand:2.8.0
-  - net.projecttl:InventoryGUI-api:4.3.0
+#  - net.projecttl:InventoryGUI-api:4.3.0
   - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0
   - io.github.monun:heartbeat-coroutines:0.0.3
   - io.github.dolphin2410:worldgen:0.0.2


### PR DESCRIPTION
# 버그 패치
- `UHCKits`에서 `Namespace` 버그 수정 (예: `EmptyLevel` -> `empty_level`)
- `InventoryGUI 4.3.0`에 플러그인 불러오기 관련 버그가 있었는데, 패치 되었지만 적용되지 않았습니다. 다음 업데이트 까지는 임시적으로 `mavenLocal`에서 불러와야 할 것 같습니다
- `Recipe`가 불러오지지 않았던 버그를 수정했습니다.
- `Forge`가 `Item`에 없어서 임시적으로 모루를 갖다 썼습니다.

# 기능 추가
플레이어 머리 먹을 때, `speed` 추가 하였습니다.

# 고치지는 않았지만 발견된 버그
- WorldGen 파일 관련 버그

PaperMC 1.18.1에서 테스트 해봤습니다
